### PR TITLE
Suggest fix for maybe-uninitialized problem

### DIFF
--- a/simulator/fp_test/fp_test.cpp
+++ b/simulator/fp_test/fp_test.cpp
@@ -542,7 +542,7 @@ void SearchSettings() {
 	TestResult_s BestResult;
 	size_t BestStep0Precision;
 	size_t BestStep1Precision;
-	size_t BestStep2Precision;
+	size_t BestStep2Precision = 0;
 	uint64_t BestStep1CorrectionFactor = 0;
 	uint64_t BestStep2CorrectionFactor = 0;
 


### PR DESCRIPTION
On g++ 11.2.0-7ubuntu2, there is an issue with [-Werror=maybe-uninitialized]

g++ -Wno-unused-function -Wno-unused-but-set-variable -std=c++14 -c -ffunction-sections -fdata-sections -g -Wall -Wno-unused-local-typedefs -Wno-reorder -fno-strict-aliasing -Wno-unused-variable -Wno-unused-result -Wno-psabi -Werror -gdwarf-2 -O3 -I. -I../sim_lib -I../httpd  -DCRAY_HOST_SYSTEM=linux -D_FILE_OFFSET_BITS=64 fp_test.cpp -c -g -o ../_obj/linux_release/fp_test.o
fp_test.cpp: In function ‘void SearchSettings()’:
fp_test.cpp:574:245: error: ‘BestStep2Precision’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  574 | n << " S1: " << BestStep1Precision << " S2: " << BestStep2Precision << " C1: " << (BestStep1CorrectionFactor << (48 - BestStep2Precision)) << " C2: " << (BestStep2CorrectionFactor << (48 - BestStep2Precision)) << std::endl;
      |                                                                                                                 ~~~~^~~~~~~~~~~~~~~~~~~~~

cc1plus: all warnings being treated as errors

This pull request fixes the problem.

Now the simulator builds and looks great, I haven't any idea how to drive the thing though.
