### PR TITLE
Add missing include

### DIFF
--- a/simulator/httpd/reply.hpp
+++ b/simulator/httpd/reply.hpp
@@ -11,6 +11,7 @@
 #ifndef HTTP_REPLY_HPP
 #define HTTP_REPLY_HPP
 
+#include <map>
 #include <string>
 #include <vector>
 #include <boost/asio.hpp>


### PR DESCRIPTION
Add missing include to fix a build issue with GCC 12

```
reply.hpp:48:8: error: 'map' in namespace 'std' does not name a template type
   48 |   std::map<std::string, std::string> headers;
      |        ^~~
reply.hpp:18:1: note: 'std::map' is defined in header '<map>'; did you forget to '#include <map>'?
   17 | #include "header.hpp"
  +++ |+#include <map>
   18 | 
```