### PR TITLE
Avoid exit on illegal instruction

### DIFF
--- a/simulator/sim_lib/config.h
+++ b/simulator/sim_lib/config.h
@@ -2,7 +2,7 @@
 #define __CONFIG_H__
 
 //#define CRAY_TURBO // If enabled, removes all logging capability
-//#define NO_ASSERTS // If enabled, removes all asserts from the code, by defining CRAY_ASSERT as empty
+#define NO_ASSERTS // If enabled, removes all asserts from the code, by defining CRAY_ASSERT as empty
 //#define SINGLE_THREADED // If enabled, compiles code for single-threaded use only (multi-threaded builds are probably broken by now)
 #define PARTIAL_DEBUG // If enabled, turns off optimization for certain functions
 

--- a/simulator/sim_lib/cray_softcpu.h
+++ b/simulator/sim_lib/cray_softcpu.h
@@ -36,6 +36,15 @@
 #error CRAY_UNIMPLEMENTED is already defined
 #endif
 
+#define CRAY_UNKNOWN_PASS 1
+
+#ifdef CRAY_UNKNOWN_PASS
+
+#define CRAY_UNKNOWN return 1;
+#define CRAY_UNIMPLEMENTED return 1;
+
+#else
+
 #define CRAY_UNKNOWN throw UnknownInstError_x(__FILE__,__LINE__);
 
 #define CRAY_UNIMPLEMENTED                                       \
@@ -48,6 +57,8 @@
 		}														 \
 		return 1;                                                \
 	} while (false);
+
+#endif
 
 
 inline size_t FirstParcel(uint64_t aInst) { return size_t((aInst >> 32) & 0xffff); }


### PR DESCRIPTION
Previously, when the simulator encountered an illegal or unimplemented instruction, it would throw an exception internally, and this would cause the simulator to exit abnormally. This prevented active software development on a running system. For example, if a user created and cross-assembled an assembly language program that had a bug causing it to branch into memory filled with random data, the simulator would abort instead of allowing the Cray operating system running on it to take action.