### PR TITLE
Add missing boost/array header to console.h

### DIFF
--- a/simulator/sim_lib/console.h
+++ b/simulator/sim_lib/console.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <boost/asio.hpp>
+#include <boost/array.hpp>
 #include "utils.h"
 #include "cray_logger.h"
 #include "debug_events.h"


### PR DESCRIPTION
Fixes build error:

```
g++  -std=c++14 -c -ffunction-sections -fdata-sections -g -Wall -Wno-unused-local-typedefs -Wno-reorder -fno-strict-aliasing -Wno-unused-variable -Wno-unused-result -Wno-psabi -Werror -gdwarf-2 -O3 -I. -I../sim_lib -I../httpd  -DCRAY_HOST_SYSTEM=linux -D_FILE_OFFSET_BITS=64 cray_channels.cpp -c -g -o ../_obj/linux_release/cray_channels.o
In file included from sim_iop_con.h:22,
                 from sim_iop.h:24,
                 from cray_mainframe.h:18,
                 from cray_channels.cpp:8:
console.h:106:31: error: field ‘mReceiveBuf’ has incomplete type ‘boost::array<char, 1>’
  106 |         boost::array<char, 1> mReceiveBuf;
      |                               ^~~~~~~~~~~
In file included from /usr/include/boost/lexical_cast/detail/converter_lexical.hpp:52,
                 from /usr/include/boost/lexical_cast/try_lexical_convert.hpp:32,
                 from /usr/include/boost/lexical_cast.hpp:33,
                 from /usr/include/boost/date_time/format_date_parser.hpp:14,
                 from /usr/include/boost/date_time/date_generator_parser.hpp:20,
                 from /usr/include/boost/date_time/date_facet.hpp:25,
                 from /usr/include/boost/date_time/gregorian/gregorian_io.hpp:16,
                 from /usr/include/boost/date_time/gregorian/gregorian.hpp:31,
                 from /usr/include/boost/date_time/posix_time/time_formatters.hpp:12,
                 from /usr/include/boost/date_time/posix_time/posix_time.hpp:24,
                 from /usr/include/boost/date_time/local_time/local_time.hpp:11,
                 from /usr/include/boost/date_time.hpp:15,
                 from logger.h:17,
                 from cray_logger.h:5,
                 from cray_channels.h:18,
                 from cray_channels.cpp:7:
/usr/include/boost/lexical_cast/detail/converter_lexical_streams.hpp:88:11: note: declaration of ‘class boost::array<char, 1>’
   88 |     class array;
      |           ^~~~~
make[1]: *** [../engine.mak:217: ../_obj/linux_release/cray_channels.o] Error 1
```