### PR TITLE
Support Full Dynamic Linking (Linux)

### DIFF
--- a/README
+++ b/README
@@ -26,6 +26,8 @@ Linux build instructions:
 4. Build
       cd cray-sim/simulator
       make build
+   Else for Linux distros that require dynamic linking do:
+      make LINK_TYPE=dynamic build
 5. Build images
       cd ../target/cos_117
       ./build_boot_tape

--- a/simulator/common.mak
+++ b/simulator/common.mak
@@ -141,7 +141,12 @@ INC_DIRS += $(DEP_INC_DIRS) $(EXTRA_INC)
 
 DEFINES += _FILE_OFFSET_BITS=64
 
+ifndef LINK_TYPE
+LINK_TYPE=static
+endif
+
 #	$(if ("$(SYSTEM)","cygwin"), $(1), :lib$(strip $(1)).a)
+ifeq ($(LINK_TYPE),static)
 define static_lib
 	:lib$(strip $(1)).a
 endef
@@ -154,6 +159,13 @@ ifeq ($(SYSTEM),mingw)
 define static_lib
 	:lib$(strip $(1))-mt.a
 endef
+endif
+else ifeq ($(LINK_TYPE),dynamic)
+define static_lib
+	$(1)
+endef
+else
+$(error LINK_TYPE must be either 'static' or 'dynamic', not '$(LINK_TYPE)')
 endif
 
 #################################################################################
@@ -181,9 +193,11 @@ COMMON_LIBS += Bcrypt
 endif
 ifeq ($(SYSTEM),linux)
 NCURSES_LIBS += $(call static_lib, ncurses)
+NCURSES_LIBS += $(call static_lib, panel)
+ifeq ($(LINK_TYPE),static)
 NCURSES_LIBS += $(call static_lib, termcap)
 NCURSES_LIBS += $(call static_lib, gpm)
-NCURSES_LIBS += $(call static_lib, panel)
+endif
 BOOST_LIBS += $(call static_lib, rt)
 COMMON_LIBS += pthread
 endif


### PR DESCRIPTION
**Full Dynamic Linking Support for Linux Distros**

The original build links in certain libraries statically and this works on Linux distros like Ubuntu that provide static libraries, but it fails at the final linking stage on distros like Arch Linux that primarily provide dynamic libraries.

To resolve, this pull request adds:

* Optional full dynamic linking support
* Usage in README

Tests:

* Tested both original and full dynamic builds on Ubuntu 22.04.3 LTS (aarch64)
* Tested dynamic build on Arch Linux (x86_64)

Usage:

```
make LINK_TYPE=dynamic build
```

ldd outputs:

```
Original build:

Ubuntu 22.04.3 LTS (aarch64):
make build
ldd _bin/linux_release/cray_sim
        linux-vdso.so.1 (0x0000ea99e4989000)
        libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ea99e4480000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ea99e43e0000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ea99e43b0000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ea99e4200000)
        /lib/ld-linux-aarch64.so.1 (0x0000ea99e4950000)

------------------------------------------------------------------------------------------------

This pull request:

Ubuntu 22.04.3 LTS (aarch64):
make build:
ldd _bin/linux_release/cray_sim
        linux-vdso.so.1 (0x0000efbaf7718000)
        libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000efbaf7210000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000efbaf7170000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000efbaf7140000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000efbaf6f90000)
        /lib/ld-linux-aarch64.so.1 (0x0000efbaf76df000)

----------------------------------

Ubuntu 22.04.3 LTS (aarch64):
make LINK_TYPE=dynamic build
ldd _bin/linux_release/cray_sim
        linux-vdso.so.1 (0x0000e8922c18e000)
        libncurses.so.6 => /lib/aarch64-linux-gnu/libncurses.so.6 (0x0000e8922bed0000)
        libtinfo.so.6 => /lib/aarch64-linux-gnu/libtinfo.so.6 (0x0000e8922be80000)
        libpanel.so.6 => /lib/aarch64-linux-gnu/libpanel.so.6 (0x0000e8922be60000)
        libboost_filesystem.so.1.74.0 => /lib/aarch64-linux-gnu/libboost_filesystem.so.1.74.0 (0x0000e8922be30000)
        libboost_thread.so.1.74.0 => /lib/aarch64-linux-gnu/libboost_thread.so.1.74.0 (0x0000e8922bdf0000)
        libboost_timer.so.1.74.0 => /lib/aarch64-linux-gnu/libboost_timer.so.1.74.0 (0x0000e8922bdd0000)
        libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000e8922bba0000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000e8922bb00000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000e8922bad0000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000e8922b920000)
        /lib/ld-linux-aarch64.so.1 (0x0000e8922c155000)
        libboost_chrono.so.1.74.0 => /lib/aarch64-linux-gnu/libboost_chrono.so.1.74.0 (0x0000e8922b900000)

----------------------------------

Arch Linux (x86_64):
make LINK_TYPE=dynamic build
ldd _bin/linux_release/cray_sim
        linux-vdso.so.1 (0x000075ebf7f7d000)
        libncursesw.so.6 => /usr/lib/libncursesw.so.6 (0x000075ebf7eb7000)
        libpanelw.so.6 => /usr/lib/libpanelw.so.6 (0x000075ebf7eaf000)
        libboost_system.so.1.86.0 => /usr/lib/libboost_system.so.1.86.0 (0x000075ebf7ea7000)
        libboost_filesystem.so.1.86.0 => /usr/lib/libboost_filesystem.so.1.86.0 (0x000075ebf7e77000)
        libboost_regex.so.1.86.0 => /usr/lib/libboost_regex.so.1.86.0 (0x000075ebf7baf000)
        libboost_thread.so.1.86.0 => /usr/lib/libboost_thread.so.1.86.0 (0x000075ebf7b8f000)
        libboost_timer.so.1.86.0 => /usr/lib/libboost_timer.so.1.86.0 (0x000075ebf7e6f000)
        libboost_chrono.so.1.86.0 => /usr/lib/libboost_chrono.so.1.86.0 (0x000075ebf7b7f000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x000075ebf7800000)
        libm.so.6 => /usr/lib/libm.so.6 (0x000075ebf7a8f000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x000075ebf77cf000)
        libc.so.6 => /usr/lib/libc.so.6 (0x000075ebf75d7000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x000075ebf7f7f000)
        libicudata.so.75 => /usr/lib/libicudata.so.75 (0x000075ebf5800000)
        libicui18n.so.75 => /usr/lib/libicui18n.so.75 (0x000075ebf5400000)
        libicuuc.so.75 => /usr/lib/libicuuc.so.75 (0x000075ebf51ff000)

```