### PR TITLE
Fix error in run. Add tmux and alternate terminal support.

### DIFF
--- a/cos_117_tmux.cfg
+++ b/cos_117_tmux.cfg
@@ -169,7 +169,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 040
 						TOChannelIdx 041
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -179,7 +179,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 042
 						TOChannelIdx 043
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -189,7 +189,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 044
 						TOChannelIdx 045
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -199,7 +199,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 046
 						TOChannelIdx 047
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -275,7 +275,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 042
 						TOChannelIdx 043
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -297,7 +297,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 042
 						TOChannelIdx 043
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes
@@ -441,7 +441,7 @@ IopClusters {
 					Console {
 						TIChannelIdx 042
 						TOChannelIdx 043
-						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						NewTerminalCommand          "tmux new-session -d -s cray_{port} -n cray_{port} '{cmd}'&"
 						ConsoleCommandLinux         "telnet {host} {port}"
 						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
 						MapBackspace                yes

--- a/cos_117_tmux.cfg
+++ b/cos_117_tmux.cfg
@@ -1,0 +1,458 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Configuration for a single-processor X-MP
+; Matches HW config for machine SN#302
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+CpuMemorySize         0x400000        ; We have 8MWords (64-bits each) of memory
+BufferMemorySize      0x400000        ; We have 8MWrods of buffer memory as well
+
+StartupCpuIdx         0              ; This will set up the first CPU to come out of reset (on instructions from the IOP)
+StartupIopIdx         0              ; The first one (the MIOP) is the one to leave reset first
+
+ClusterCount          3              ; Single-processor machines have 3 clusters - that is the number of inter-processor communication register sets
+
+MemoryDumpFile        dump/mem.dmp        ; If we get terminated, dump mainframe memory to this file
+BufferMemoryDumpFile  dump/buffer.dmp     ; If we get terminated, dump buffer memory to this file
+
+MultiThreaded         no
+MachineType           XMP1
+
+WindowWidth           120
+WindowHeight          40
+
+DefaultLogLevel       None
+
+EnableTimeStamp       yes
+
+
+LogFileName           dump/cray_sim.log
+
+OsType                COS
+
+LogUnusedChannels     no
+
+BreakPoints {
+}
+
+EventPoints {
+}
+
+WatchPoints {
+}
+
+CpuCount 1
+Cpus {
+	Default {
+;		HistoryBuffer 1000000
+;		DefaultLogLevel All
+;		InstructionBurstSize 100
+;		TimerIncrement 1000
+;		MemoryPokes {
+;			0x00207B:p0 0006000 ; Change JSP to J to skip mainframe memory test
+;		}
+		ThrowOnUnknown no
+		ThrowOnUnimplemented no
+	}
+}
+
+IopClusters {
+	IopDCluster {
+		BufferMemoryPokes {
+				0x42B7 0x0200 ; Patch up IOP memory test routine to exit immediately
+				0x4476 0x0000 ; Patch up ovrelay loading code not to clear end of memory: it's 0 already in the simulator
+				0x43DA 0x0000 ; Patch up buffer memory test to exit quickly
+				0x3939 0x0028 ; Set CK0 device address to 050 - Hayes clock (should be 070 for Chronolog clocks)
+			; Make sure we always wait for completion on IOP-to-IOP transfers
+			;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+			;	0x09BC 0x7e00
+			;	0x0a36 0x0000
+			;	0x0a59 0x0000
+			;	0x0a80 0x7710
+		}
+
+		BufferImageFiles {
+			0x0000 target/cos_117/iop_kern.bin               ; The first IOP boots from buffer memory. Pre-load the boot image.
+		}
+		
+		Iops {
+			0 {
+				MemoryDumpFile dump/iop0.dmp
+;				DefaultLogLevel None
+				Type MIOP
+				ChannelCount 42
+				InstructionBurstSize 100
+				TimerLimit 79999
+				Channels {
+					ERA {
+						ChannelIdx 016
+					}
+					Expander {
+						ChannelIdx 017
+						DeviceCount 64
+						Devices {
+							Tape {
+								ChannelIdx 022
+								Interrupt 5
+								Tape boot_tape.tap
+								Pokes {
+									boot_tape.tap {
+										0 {
+											0x04610 { Size 2 Value 0x1001 BigEndien yes } ; override long delay in INDD29 to speed bootup
+		;									0x1E2C0 { Size 2 Value 0x0010 BigEndien yes } ; override large loop in XDK to quickly terminate
+		;									0x256fd { Size 2 Value 0x0000 BigEndien yes } ; override call to MFINIT in START0
+		;									0x25783 { Size 2 Value 0x0000 BigEndien yes } ; override call to YIELD in START0
+											;0x4aefb { Size 1 Value 0x01 } ; override call to long delay in START0
+											0x3D24B { Size 1 Value 0x28 } ; Make XCLOCK restore the proper device address upon exit
+											0x3d6a3 { Size 1 Value 0x28 } ; Make XCLOCK use channel 51 for responses
+											0x3d7c3 { Size 1 Value 0x28 } ; Make XCLOCK use channel 51 for responses
+											0x3d399 { Size 1 Value 0x28 } ; Make XCLOCK use channel 51 for responses
+											0x3d49b { Size 1 Value 0x28 } ; Make XCLOCK use channel 51 for responses
+		;									0x138F5 { Size 2 Value 0x1010 BigEndien yes } ; patch up timeout in BMXCON
+											; Make calls for buffer transfer in START3 WAIT for return to work around synchrnization problems between IOPs in a multi-thread simulation
+											;0x4b797 { Size 1 Value 0x00 }
+		;									0x25BCB { Size 2 Value 0x1000 } ; A = 0
+		;									0x25BCF { Size 2 Value 0x1800 } ; A = ...
+		;									0x25BD0 { Size 2 Value 0x1D18 } ;     0x1D18
+		;									0x25BD1 { Size 2 Value 0x7C09 } ; R = OR[9]
+		;									0x25BD2 { Size 2 Value 0x2119 } ; A = OR[281]
+		;									0x25BD3 { Size 2 Value 0x8607 } ; P = P + 7, A # 0
+										}
+									}
+								}
+							}
+							AmpexDM980Disk {
+		;						Must be an Ampex DM980 from this: http://bitsavers.trailing-edge.com/pdf/dilog/30006-1_DQ202A_Sep81.pdf - though as far as format goes, it seems identical to the CDC SMD9762
+		;						It's a 80MB drive, but formatted as a 64MB one (leaving the last sector on each track empty)
+								;DefaultLogLevel All
+								ChannelIdx 060
+								Interrupt 6
+								ImageFileName exp_disk.img
+								Heads 5
+								Sectors 35
+								Tracks 823
+								SectorSize 512
+							}
+							Printer {
+								ChannelIdx 017
+								Interrupt 3
+								Name PR0
+								PrintFileName pr0.txt
+							}
+							Clock {
+								;DefaultLogLevel All
+								PrimaryChannelIdx 050
+								Interrupt 1
+								Name CK0
+								ResponseTimeout 500
+								YearLimit yes
+							}
+						}
+						;UseDummyDevices yes
+					}
+					CI {
+;						DefaultLogLevel All
+						IopChannelIdx 020
+						CrayChannelIdx 9
+					}
+					CO {
+;						DefaultLogLevel All
+						IopChannelIdx 021
+						CrayChannelIdx 8
+					}
+					CONC {
+						InputChannelIdx 024
+						OutputChannelIdx 025
+						PollDelay 100
+					}
+					Console {
+						TIChannelIdx 040
+						TOChannelIdx 041
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+					Console {
+						TIChannelIdx 042
+						TOChannelIdx 043
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+					Console {
+						TIChannelIdx 044
+						TOChannelIdx 045
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+					Console {
+						TIChannelIdx 046
+						TOChannelIdx 047
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+				}
+				BreakPoints {
+		;			0x210F { Type Trace Message "FATAL handler called {stack}" }
+		;			0x326A { Type LogOn }
+		;;			0x3ba6 { Type LogOn }
+		;			0x1697 { Type LogOn } ; Breakpoint in error case of HSPW
+		;			0x169D { Type Terminate }
+		;;			0x167C { Type LogOn } ; Breakpoint in the call that fails
+		;			0x4C58 { Type Trace Message "0x4C58 called {stack}" }
+		;			0x167C { Type Trace Message "0x167C called {stack}" }
+		;			0x1716 { Type Trace Message "0x1716 called {stack}" }
+		;			0x47EB { Type Trace Message "passing through 0x47EB {stack}" }
+				}
+				EventPoints {
+		;			"CPU0 Coming out of reset" { Type LogOn TriggerCnt 2 }
+				}
+			}
+			1 {
+				MemoryDumpFile dump/iop1.dmp
+				Type BIOP
+				ChannelCount 42
+				InstructionBurstSize 100
+				TimerLimit 79999
+				Channels {
+					HIA {
+						ChannelIdx 014
+					}
+					HOA {
+						ChannelIdx 015
+					}
+					DD29 {
+						ChannelIdx 020
+						ImageFileName disk/biop_dk20.img
+					}
+					DD29 {
+						ChannelIdx 021
+						ImageFileName disk/biop_dk21.img
+					}
+					DD29 {
+						ChannelIdx 022
+						ImageFileName disk/biop_dk22.img
+					}
+					DD29 {
+						ChannelIdx 024
+						ImageFileName disk/biop_dk24.img
+					}
+					DD29 {
+						ChannelIdx 025
+						ImageFileName disk/biop_dk25.img
+					}
+					DD29 {
+						ChannelIdx 026
+						ImageFileName disk/biop_dk26.img
+					}
+					DD29 {
+						ChannelIdx 030
+						ImageFileName disk/biop_dk30.img
+					}
+					DD29 {
+						ChannelIdx 031
+						ImageFileName disk/biop_dk31.img
+					}
+					DD29 {
+						ChannelIdx 032
+						ImageFileName disk/biop_dk32.img
+					}
+					Console {
+						TIChannelIdx 042
+						TOChannelIdx 043
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+				}
+				BreakPoints {
+				}
+			}
+			2 {
+				Exists no
+				MemoryDumpFile dump/iop2.dmp
+				Type DIOP
+				ChannelCount 42
+				InstructionBurstSize 100
+				TimerLimit 79999
+				Channels {
+					Console {
+						TIChannelIdx 042
+						TOChannelIdx 043
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+				}
+				BreakPoints {}
+			}
+			3 {
+				MemoryDumpFile dump/iop3.dmp
+				Type XIOP
+				ChannelCount 42
+				InstructionBurstSize 100
+				TimerLimit 79999
+				Channels {
+					Bmx {
+						ChannelIdx 020
+						DelayLimit 10
+						Devices {
+							Tape {
+								DeviceName BmxTape0
+								DeviceAddress 0x0
+								Tape tape/bmt_00.tap
+							}
+							Tape {
+								DeviceName BmxTape1
+								DeviceAddress 0x1
+								Tape tape/bmt_01.tap
+							}
+							Tape {
+								DeviceName BmxTape2
+								DeviceAddress 0x2
+								Tape tape/bmt_02.tap
+							}
+							Tape {
+								DeviceName BmxTape3
+								DeviceAddress 0x3
+								Tape tape/bmt_03.tap
+							}
+							Tape {
+								DeviceName BmxTape4
+								DeviceAddress 0x4
+								Tape tape/bmt_04.tap
+							}
+							Tape {
+								DeviceName BmxTape5
+								DeviceAddress 0x5
+								Tape tape/bmt_05.tap
+							}
+							Tape {
+								DeviceName BmxTape6
+								DeviceAddress 0x6
+								Tape tape/bmt_06.tap
+							}
+							Tape {
+								DeviceName BmxTape7
+								DeviceAddress 0x7
+								Tape tape/bmt_07.tap
+							}
+						}
+					}
+					Bmx {
+						ChannelIdx 021
+						DelayLimit 10
+						Devices {
+							Tape {
+								DeviceName BmxTape8
+								DeviceAddress 0x8
+								Tape tape/bmt_08.tap
+							}
+							Tape {
+								DeviceName BmxTape9
+								DeviceAddress 0x9
+								Tape tape/bmt_09.tap
+							}
+							Tape {
+								DeviceName BmxTape10
+								DeviceAddress 0xa
+								Tape tape/bmt_10.tap
+							}
+							Tape {
+								DeviceName BmxTape11
+								DeviceAddress 0xb
+								Tape tape/bmt_11.tap
+							}
+							Tape {
+								DeviceName BmxTape12
+								DeviceAddress 0xc
+								Tape tape/bmt_12.tap
+							}
+							Tape {
+								DeviceName BmxTape13
+								DeviceAddress 0xd
+								Tape tape/bmt_13.tap
+							}
+							Tape {
+								DeviceName BmxTape14
+								DeviceAddress 0xe
+								Tape tape/bmt_14.tap
+							}
+							Tape {
+								DeviceName BmxTape15
+								DeviceAddress 0xf
+								Tape tape/bmt_15.tap
+							}
+						}
+					}
+					Bmx {
+						ChannelIdx 022
+						DelayLimit 10
+						Devices {
+							Tape {
+								DeviceName BmxTape16
+								DeviceAddress 0x8
+								Tape tape/bmt_16.tap
+							}
+							Tape {
+								DeviceName BmxTape17
+								DeviceAddress 0xc0
+								Tape tape/bmt_17.tap
+							}
+						}
+					}
+					Bmx {
+						ChannelIdx 023
+						DelayLimit 10
+						Devices {
+							Tape {
+								DeviceName BmxTape18
+								DeviceAddress 0x8
+								Tape tape/bmt_18.tap
+							}
+							Tape {
+								DeviceName BmxTape19
+								DeviceAddress 0xc0
+								Tape tape/bmt_19.tap
+							}
+						}
+					}
+					Console {
+						TIChannelIdx 042
+						TOChannelIdx 043
+						NewTerminalCommand          "tmux new-window -d -t cray -n cray_{port} '{cmd}'&"
+						ConsoleCommandLinux         "telnet {host} {port}"
+						ConsoleCommandWindows       "putty.exe  -load Unicos -telnet  -P {port} {host}"
+						MapBackspace                yes
+						BackspaceChar               127
+						EatLf                       no
+					}
+				}
+				BreakPoints {
+				}
+			}
+		}
+	}
+}
+

--- a/gen_term_run_cfg
+++ b/gen_term_run_cfg
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+usage() {
+cat << EOF
+
+Generate run script and configuration for cray_sim
+to launch consoles in alternate terminals instead of
+xterm.
+
+Usage: $0 <terminal-name>
+
+  Example    - $0 cool-retro-term
+
+EOF
+}
+
+# Sanity checks
+if [ "$#" -ne 1 ]; then usage; exit 1; fi
+if [[ ! -f run ]]; then echo "Error: No run file."; exit 1; fi
+if [[ ! -f cos_117.cfg ]]; then echo "Error: No cos_117.cfg file."; exit 1; fi
+
+terminal_name="$1"
+
+# Uniform naming: - to _
+term_suffix="${terminal_name//-/_}"
+cp run "run_${term_suffix}"
+cp cos_117.cfg "cos_117_${term_suffix}.cfg"
+
+# Replace cos_117.cfg and xterm in targets
+sed -i "s/xterm/${terminal_name}/g" "cos_117_${term_suffix}.cfg"
+sed -i "s/cos_117.cfg/cos_117_${term_suffix}.cfg/" "run_${term_suffix}"
+chmod +x "run_${term_suffix}"
+
+cat << EOF
+
+Target Terminal           :  ${terminal_name}
+Generated run script      :  run_${term_suffix}
+Generated configuration   :  cos_117_${term_suffix}.cfg
+
+Genaration Successful!"
+
+EOF

--- a/run
+++ b/run
@@ -1,8 +1,7 @@
 #!/bin/sh
 PATH=$PATH:simulator/_bin/cygwin_release:simulator/_bin/linux_release:bin
 
-mkdir dump
-mkdir disk
-mkdir tape
+mkdir -p dump disk tape
+
 cray_sim cos_117.cfg
 

--- a/run_tmux
+++ b/run_tmux
@@ -1,7 +1,6 @@
 #!/bin/sh
 PATH=$PATH:simulator/_bin/linux_release
 
-# Usage message
 usage() {
 cat << EOF
 
@@ -53,8 +52,10 @@ cray_is_up() {
 start_cray() {
     if cray_is_up; then msg "running"; else
         mkdir -p dump disk tape
-        tmux new-session -d -s cray
-        #space for future tmux hooks here
+        tmux new-session -d -s cray 
+        # Simplify the hooks, they could be error prone 
+        tmux set-hook -t cray -g session-created 'run-shell "tmux list-sessions -F '#{session_name}' | grep '^cray_' | sort | while read -r session; do tmux move-window -s $session:0 -t cray:; done; tmux move-window -s cray:$(tmux list-windows -t cray | grep -n 'cray_sim' | cut -d: -f1) -t cray:0"'
+        tmux set-hook -t cray -g window-linked 'run-shell "tmux list-windows -t cray -F \"#{window_index}\" | awk '\''$1 != \"0\" {print \"tmux rename-window -t \" $1 \" console_\" NR-1}'\'' | bash"'
         tmux send-keys -t cray 'cray_sim cos_117_tmux.cfg' C-m
         msg "started"
         help
@@ -95,7 +96,6 @@ restart_cray() {
 
 # Attach to the cray simulator session
 attach_cray() { if cray_is_up; then tmux attach-session -t cray; else msg "not_up"; fi }
-
 
 # Display status of cray simulator session and consoles
 status_cray() {

--- a/tmux_run
+++ b/tmux_run
@@ -1,0 +1,156 @@
+#!/bin/sh
+PATH=$PATH:simulator/_bin/linux_release
+
+# Usage message
+usage() {
+cat << EOF
+
+Usage: $0 {start|stop|restart|kill|attach|status}
+
+  start    - Start cray simulator session
+  stop     - Stop cray simulator session
+  restart  - Restart cray simulator session
+  kill     - Kill cray simulator session (unsafe)
+  attach   - Attach to cray simulator session
+  status   - List running cray simulator and consoles
+
+EOF
+}
+
+# Quick tmux help
+help() {
+cat << EOF
+
+Run "tmux_run" or "tmux_run attach" to attach to simulator session.
+Or use 'tmux attach' or 'tmux attach-session -t cray'
+Use keys 'Ctrl b <0 to ...>' to move to specific windows
+Use keys 'Ctrl b n' to move to next window
+Use keys 'Ctrl b p' to move to previous window
+Use keys "Ctrl b d" to detach from simulator session.
+
+EOF
+}
+
+# Status messages
+msg() {
+    case "$1" in
+        "not_up")       echo "No cray simulator session is running." ;;
+        "running")      echo "A cray simulator session is already running." ;;
+        "started")      echo "Started!" ;;
+        "stopped")      echo "Stopped!" ;;
+        "killed")       echo "Killed!" ;;
+        "restarting")   echo "Restarting!" ;;
+        "unknown")      echo "Unknown choice: Exiting.";;
+    esac
+}
+
+# Check if cray simulator session is up
+cray_is_up() {
+    tmux has-session -t cray 2>/dev/null
+}
+
+# Start cray simulator session
+start_cray() {
+    if cray_is_up; then msg "running"; else
+        mkdir -p dump disk tape
+        tmux new-session -d -s cray
+        #space for future tmux hooks here
+        tmux send-keys -t cray 'cray_sim cos_117_tmux.cfg' C-m
+        msg "started"
+        help
+    fi
+}
+
+# Stop cray simulator session
+stop_cray() {
+    if cray_is_up; then
+        tmux select-window -t cray:0
+        tmux send-keys -t cray:0 'exit' C-m
+        tmux send-keys -t cray:0 'exit' C-m
+        msg "stopped"
+    else msg "not_up"; fi
+}
+
+# Kill cray simulator session (unsafe)
+kill_cray() {
+    if cray_is_up; then
+        tmux kill-session -t cray
+        killall -9 cray_sim
+        msg "killed"
+        echo "Try 'killall -9 cray_sim' / kill -9 <pid of cray_sim> followed"
+        echo "by 'tmux_run stop' / 'tmux_run kill' again if it is hanging!"
+    else msg "not_up"; fi
+}
+
+# Restart cray simulator session
+restart_cray() {
+    if cray_is_up; then
+        msg "restarting"
+        stop_cray
+        sleep 3
+        if cray_is_up; then kill_cray; fi
+        start_cray
+    else msg "not_up"; fi
+}
+
+# Attach to the cray simulator session
+attach_cray() { if cray_is_up; then tmux attach-session -t cray; else msg "not_up"; fi }
+
+
+# Display status of cray simulator session and consoles
+status_cray() {
+    if cray_is_up; then
+        echo "Simulator Session:"
+        tmux ls | grep -i cray
+        echo "Consoles:"
+        tmux list-windows -t cray
+    else msg "not_up"; fi
+}
+
+# Show conditional menu
+show_menu() {
+    if cray_is_up; then
+        cat << EOF
+
+1. Stop
+2. Restart
+3. Kill
+4. Status
+5. Attach
+
+EOF
+    else echo "1. Start"; fi
+}
+
+# Pick a choice from conditonal menu 
+pick_choice() {
+    show_menu
+    echo "Enter the number of your choice (or press any key to exit):"
+    read -r choice
+    if cray_is_up; then
+        case "$choice" in
+            1) stop_cray ;;
+            2) restart_cray ;;
+            3) kill_cray ;;
+            4) status_cray ;;
+            5) attach_cray ;;
+            *) msg "unknown" ;;
+        esac
+    else
+        case "$choice" in
+            1) start_cray ;;
+            *) msg "unknown" ;;
+        esac
+    fi
+}
+
+# Main CLI logic
+case "$1" in
+    start)      if cray_is_up; then msg "running";  else start_cray;   fi ;;
+    stop)       if cray_is_up; then stop_cray;      else msg "not_up"; fi ;;
+    restart)    if cray_is_up; then restart_cray;   else msg "not_up"; fi ;;
+    kill)       if cray_is_up; then kill_cray;      else msg "not_up"; fi ;;
+    status)     if cray_is_up; then status_cray;    else msg "not_up"; fi ;;
+    attach)     if cray_is_up; then attach_cray;    else msg "not_up"; fi ;;
+    *) usage;   if cray_is_up; then msg "running";  else msg "not_up"; fi; pick_choice ;;
+esac


### PR DESCRIPTION
This pull request adds the following enhancements and fixes:

1. **Alternate Terminal Support for Linux**
2. **tmux Support for Linux**
3. **Update run**

---
**Alternate Terminal Support for Linux**

The `run` script with `cos_117.cfg` spawns xterms for consoles, but users may prefer other terminals such as konsole, ~~gnome-terminal~~ or even cool-retro-term.

To resolve, this pull request adds alternate terminal support via:

+ gen_term_run_cfg - Generates run script and config combo for any alternate terminal.

Benefit:

- Consoles will launch in the user's desired terminal when the generated script is executed.

Usage:

```
gen_term_run_cfg <terminal-name>
```

Full Usage:
```
Generate run script and configuration for cray_sim
to launch consoles in alternate terminals instead of
xterm.

Usage: ./gen_term_run_cfg <terminal-name>

  Example    - ./gen_term_run_cfg cool-retro-term

```

Tests:

- The script was checked in shellcheck with no issues detected.
- Tested on Ubuntu 22.04.3 LTS (aarch64)
- Tested on Arch Linux (x86_64)
---

**tmux Support for Linux**

The `run` script with `cos_117.cfg` spawns xterms for consoles, which works well on desktops but not on VPS/servers without X forwarding or for users preferring SSH/shell/mosh.

To resolve, this pull request adds tmux support via:

+ run_tmux - Script that manages a cray simulator session.
+ cos_117_tmux.cfg - Modified config that spawns tmux windows instead of xterms.

Benefits:

- Organizes cray simulator and consoles as tmux windows in a tmux session.
- Allows attaching, detaching, and exiting without stopping the simulator.
- Console windows can be scripted to pass input / output for development.

Usage:

```
run_tmux start
run_tmux attach
or execute `run_tmux` and select from menu.
```

Full Usage:
```
Usage: run_tmux {start|stop|restart|kill|attach|status}

start - Start the Cray simulator session
stop - Stop the Cray simulator session
restart - Restart the Cray simulator session
kill - Kill the Cray simulator session (unsafe)
attach - Attach to the Cray simulator session
status - List running Cray simulator and consoles

Use keys 'Ctrl b <0 to ...>' to move to specific windows
Use keys 'Ctrl b n' to move to the next window
Use keys 'Ctrl b p' to move to the previous window
Use keys 'Ctrl b d' to detach from the simulator session.
```

Tests:

- The script was checked in shellcheck with minimal issues detected.
- Tested on Ubuntu 22.04.3 LTS (aarch64)
- Tested on Arch Linux (x86_64)

---
**Update run**

Use mkdir -p to resolve the following errors:

```

mkdir: cannot create directory ‘dump’: File exists
mkdir: cannot create directory ‘disk’: File exists
mkdir: cannot create directory ‘tape’: File exists

```